### PR TITLE
Depend on railties instead of rails

### DIFF
--- a/thor-rails.gemspec
+++ b/thor-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'thor'
-  spec.add_dependency 'rails'
+  spec.add_dependency 'railties'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
A rails application may use subset of rails dependencies - e.g. excluding sprockets. To minimize dependency, it's better to depend just on railties.